### PR TITLE
Add tinct to Colorschemes/colorscheme-generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -537,6 +537,7 @@
 
 - [oomox](https://github.com/themix-project/oomox) - Graphical application for generating different color variations of a Materia and Oomox themes (GTK2, GTK3 and others). (python)
 - [Paletty](https://paletty.dev) - Terminal color scheme generator and theme gallery. Generate from scratch, extract from image, or browse community themes. Exports to Ghostty, Alacritty, Kitty, WezTerm, iTerm2, and more.
+- [tinct](https://github.com/jmylchreest/tinct) - Plugin-based theme/templating tool inspired by Pywal and Matugen, with multiple input mechanisms (wallpaper, hex codes, image URLs, time-of-day). (go)
 - [wpgtk](https://github.com/deviantfero/wpgtk) - a colorscheme, wallpaper and template manager for \*nix. (python)
 
 ---


### PR DESCRIPTION
[tinct](https://github.com/jmylchreest/tinct) is a Pywal/Matugen-style colour-scheme generator and templating tool (Go).

Plugin-based: multiple input mechanisms (wallpaper, hex codes, image URLs, time-of-day) all feed the same templating engine. Renders templates for any consumer that needs a palette — terminals, status bars, OSDs, GTK / Qt themes, etc. Pairs naturally with wallpaper daemons (swww, hyprpaper) and notification daemons that read theme palettes from disk.

Inserted alphabetically between \`Paletty\` and \`wpgtk\` in the colorscheme-generators subsection.